### PR TITLE
PHP 8.4 compatability: Make parameter types explicitly nullable

### DIFF
--- a/src/Tag/Tag.php
+++ b/src/Tag/Tag.php
@@ -292,7 +292,7 @@ abstract class Tag implements JsonSerializable
      * @return Tag
      * @throws Exception
      */
-    public static function load(Reader $reader, ?TagOptions $options = null, Tag $parent = null): Tag
+    public static function load(Reader $reader, ?TagOptions $options = null, ?Tag $parent = null): Tag
     {
         if($options === null) {
             $options = new TagOptions();


### PR DESCRIPTION
In PHP 8.4 implicitly marking parameters as nullable is deprecated. This PR explicitly marks the parameters as nullable by adding a `?` to the parameter types with a default value of null (`= null`).